### PR TITLE
Multiple Changes

### DIFF
--- a/Assets/Scripts/Controls.cs
+++ b/Assets/Scripts/Controls.cs
@@ -52,6 +52,7 @@ public class Controls : MonoBehaviour
                 Vector2Int mp = (Vector2Int)Vector3Int.RoundToInt(cam.ScreenToWorldPoint(Input.mousePosition));
                 cUnit.go.GetComponent<UnitGO>().PathToTile(world.tiles[mp.x, mp.y]);
             }
+            GameManager.Instance.unitManager.selectedUnits = new List<Unit>();
         }
     }
 

--- a/Assets/Scripts/Pathfinding.cs
+++ b/Assets/Scripts/Pathfinding.cs
@@ -45,27 +45,27 @@ public class Pathfinding
         World world = GameManager.Instance.world;
 
         // Left
-        if(tile.position.x - 1 >= 0){
+        if(tile.position.x - 1 >= 0 && world.tiles[tile.position.x - 1, tile.position.y].tileData.walkable){
             neighbourList.Add(world.tiles[tile.position.x - 1, tile.position.y]);
             // LDown
-            if(tile.position.y - 1 >= 0){
+            if(tile.position.y - 1 >= 0 && world.tiles[tile.position.x, tile.position.y - 1].tileData.walkable){
                 neighbourList.Add(world.tiles[tile.position.x - 1, tile.position.y - 1]);
             }
             // LUp
-            if(tile.position.y + 1 < world.height){
+            if(tile.position.y + 1 < world.height && world.tiles[tile.position.x, tile.position.y + 1].tileData.walkable){
                 neighbourList.Add(world.tiles[tile.position.x - 1, tile.position.y + 1]);
             }
         }
 
         // Right
-        if(tile.position.x + 1 < world.width){
+        if(tile.position.x + 1 < world.width && world.tiles[tile.position.x + 1, tile.position.y].tileData.walkable){
             neighbourList.Add(world.tiles[tile.position.x + 1, tile.position.y]);
             // RDown
-            if(tile.position.y - 1 >= 0){
+            if(tile.position.y - 1 >= 0 && world.tiles[tile.position.x, tile.position.y - 1].tileData.walkable){
                 neighbourList.Add(world.tiles[tile.position.x + 1, tile.position.y - 1]);
             }
             // RUp
-            if(tile.position.y + 1 < world.height){
+            if(tile.position.y + 1 < world.height && world.tiles[tile.position.x, tile.position.y + 1].tileData.walkable){
                 neighbourList.Add(world.tiles[tile.position.x + 1, tile.position.y + 1]);
             }
         }

--- a/Assets/Scripts/UnitGO.cs
+++ b/Assets/Scripts/UnitGO.cs
@@ -36,7 +36,12 @@ public class UnitGO : MonoBehaviour
         {
             target = path[i].go.transform.position;
             while ((Vector2)go.transform.position != target) {
-                if(dest.occupyingUnit != null) return; // Maybe search for nearby tiles in future?
+                if(dest.occupyingUnit != null){
+                    parent.occupypingTile.occupyingUnit = null;
+                    parent.occupypingTile = path[i];
+                    path[i].occupyingUnit = parent;
+                    return; // Maybe search for nearby tiles in future?
+                } 
                 
                 await Task.Yield();
             }


### PR DESCRIPTION
selectedUnits is now cleared when the player moves a unit.

The pathfinding algorithm now ensures that when trying to move diagonally, the tiles above and below are checked to ensure corners are not cut.

UnitGO now updates the occupyingTile and occupyingUnit variables correctly when the destination is taken up by another unit mid pathing.

:chart: